### PR TITLE
Fix namechange command bug

### DIFF
--- a/cmd/osu! and osu!droid/namechange.js
+++ b/cmd/osu! and osu!droid/namechange.js
@@ -265,7 +265,7 @@ module.exports.run = (client, message, args, maindb, alicedb) => {
                 return message.channel.send("❎ **| I'm sorry, this part of the command is only allowed in DMs for privacy reasons.**");
             }
 
-            if (args.length !== 2) return message.channel.send("❎ **| Hey, spaces in nicknames are not allowed!**");
+            if (args.length > 2) return message.channel.send("❎ **| Hey, spaces in nicknames are not allowed!**");
 
             const email = args[0];
             if (!email) return message.channel.send("❎ **| Hey, please enter your email address!**");


### PR DESCRIPTION
this should stop the command from returning a "Hey, spaces in nicknames are not allowed!" response when only one argument is passed